### PR TITLE
v1.2.0 add --hard-links options and local copy ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+CHANGELOG
+=========
+
+## v1.2.0
+
+ * allow local backup by commenting BACKUP_SERVER=
+ * auto suggest container name, introduce "storage" term
+ * add --hard-links option
+ * append container name by trailing slash "/"
+ * skip sending backup.log for --dry-run
+ * allow custom rsync args by CUSTOM_ARGS= or by passing shell arguments
+

--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ STORAGE="family_photos"
 
 ## Exclude paths from backup
 
-Create file named `backup-ignore`
+Create file named `backup-ignore`. See `backup-ignore-sample` as reference.

--- a/README.md
+++ b/README.md
@@ -2,25 +2,32 @@
 Simple cross-patform rsync backup
 =================================
 
-## Setup on Server
+Single-file backup script which lives in the target directory alongside with data and points to actual backup storage.
 
-### Use rsync-3.1.2+
+Backup always simple as invoking `./backup.sh`
 
-On Ubuntu 14.04 it needed to be complied from sources.
+## Few concepts
 
- * Download latest from https://rsync.samba.org/ and unpack
+`CONTAINER` is a bunch of data which you'd like to keep together, like your documents or photos
+`STORAGE` is a place on the backup disk/server keeping multiple **containers**
 
-```bash
-$ sudo apt-get install checkinstall
-$ ./configure
-$ make
-$ sudo apt-get remove rsync
-$ sudo checkinstall
+By default **container** name is the current directory name, but you can override it by `CONTAINER=` option.
+
+## Examples
+
+```
+./backup.sh   # perform backup
 ```
 
-## Install & Setup on Client
+```
+./backup.sh --verbose   # append custom attributes to rsync
+```
 
-### Install on Windows
+## Prerequisites for Server and Client
+
+install rsync-3.1.2+
+
+## Install rsync and ssh on Windows
 
  * Download from http://msys2.org/
  * Follow instructions for update packman
@@ -30,7 +37,7 @@ $ sudo checkinstall
 $ pacman -S rsync openssh
 ```
 
-### Setup ssh config
+## Setup ssh config
 
  * Create ssh key 
 
@@ -52,22 +59,22 @@ Host backup-server
 $ ssh-copy-id user@backup-server
 ```
 
-### Setup backup config
+## Setup backup config
 
  * Copy `backup-sample.sh` into target folder as `backup.sh`.
- * Open `backup.sh` and specify correct values for `BACKUP_SERVER` and `CONTAINER`
+ * Open `backup.sh` and specify correct values for `BACKUP_SERVER` and `STORAGE`
 
 Examples:
 
 ```bash
 BACKUP_SERVER="user@backup-server"
-CONTAINER="family_photos"
+STORAGE="family_photos"
 ```
 
  * test in `--dry-run (-n)` mode
- * remove `--dry-run (-n)` options
+ * remove `--dry-run (-n)` option by commenting DEBUG= variable
 
-#### Windows launcher as .sh association
+### Windows launcher as .sh association
 
  * copy appropriate 32/64 version of `sh_launcher{32/64}.cmd` as `C:\msys{32/64}\sh_launcher.cmd`
  * apply appropriate 32/64 version of `msys2_32_sh.reg`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Single-file backup script which lives in the target directory alongside with dat
 
 Backup always simple as invoking `./backup.sh`
 
+NOTE: this is mirror-style backup, everything you have deleted in your working copy would be removed on a backup storage during sync (`rsync --delete` option). It's assumed your are using hard links snapshots on a backup storage if you'd like keep previous files versions.
+
 ## Few concepts
 
 `CONTAINER` is a bunch of data which you'd like to keep together, like your documents or photos.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Backup always simple as invoking `./backup.sh`
 
 ## Few concepts
 
-`CONTAINER` is a bunch of data which you'd like to keep together, like your documents or photos
-`STORAGE` is a place on the backup disk/server keeping multiple **containers**
+`CONTAINER` is a bunch of data which you'd like to keep together, like your documents or photos.
+
+`STORAGE` is a place on the backup disk/server keeping multiple **containers**.
 
 By default **container** name is the current directory name, but you can override it by `CONTAINER=` option.
 

--- a/backup-ignore-sample
+++ b/backup-ignore-sample
@@ -1,0 +1,6 @@
+.cache
+.PlayOnLinux
+.rbenv
+.local/share/Trash
+.npm
+.config/google-chrome/Default/Service Worker/CacheStorage

--- a/backup-sample.sh
+++ b/backup-sample.sh
@@ -2,23 +2,60 @@
 
 #
 # https://github.com/x2es/simple-rsync-backup
-# v1.1.0
+# v1.2.0
 # 
 
-BACKUP_SERVER="x2es@backup.coolcab.org"
-CONTAINER="backup/container"
+# test your configuration and comment out DEBUG_ARGS after
+DEBUG_ARGS="--dry-run"
+
+# comment BACKUP_SERVER for local copy
+BACKUP_SERVER="user@backup.coolcab.org"
+
+# NOTE: non-absolute path points to user's home
+STORAGE="backup/storage"
+
+# by default CONTAINER is the name of the current directory
+# CONTAINER="custom-name"
+
 LOG_FILE="./backup.log"
 
-BACKUP_TARGET="$BACKUP_SERVER:~/$CONTAINER"
+# COMPRESS="--compress" # old compress
+COMPRESS="-zz" # works with rsync-3.1.2
+
+# prserve hard links
+# HARDLINKS="--hard-links"
+
+# Append your custom rsync args by setting CUSTOM_ARGS=
+# or by passing params to this script
+# CUSTOM_ARGS=""
+
+#                    #
+# --- CONFIG END --- #
+#                    #
+
+[[ -z "$CONTAINER" ]] && CONTAINER="$(basename $(pwd))"
+CONTAINER_PATH="$STORAGE/$CONTAINER"
+
+[[ ! -z "${@}" ]] && CUSTOM_ARGS="$CUSTOM_ARGS ${@}"
+
+[[ ! -z "$BACKUP_SERVER" ]]             && BACKUP_TARGET="$BACKUP_SERVER:"
+[[ "${CONTAINER_PATH:0:1}" != "/" ]]    && BACKUP_TARGET="${BACKUP_TARGET}~/"
+BACKUP_TARGET="${BACKUP_TARGET}${CONTAINER_PATH}/"
 
 EXCLUDE_LIST="./backup-ignore"
 EXCLUDE_ARG=""
 [[ -f $EXCLUDE_LIST ]] && EXCLUDE_ARG="--exclude-from=$EXCLUDE_LIST --delete-excluded"
 
 echo "Backup:"
+[[ ! -z "$DEBUG_ARGS" ]] && echo "  DEBUG: $DEBUG_ARGS"
+
+TARGET_NODE="$BACKUP_SERVER"
+[[ -z "$TARGET_NODE" ]] && TARGET_NODE="local"
+
 echo "        dir: `pwd`"                
-echo "         to: $BACKUP_SERVER"      
-echo "  container: $CONTAINER"
+echo "         to: $TARGET_NODE"
+echo "  container: $CONTAINER_PATH"
+[[ ! -z "$CUSTOM_ARGS" ]] && echo "custom args: $CUSTOM_ARGS"
 
 if [[ "$EXCLUDE_ARG" != "" ]]; then
   echo
@@ -31,13 +68,12 @@ echo
 echo "(press ENTER for continue / Ctrl+C for cancel)"
 read
 
-# COMPRESS="--compress" # old compress
-COMPRESS="-zz" # works with rsync-3.1.2
+COMMON_ARGS="$DEBUG_ARGS --archive $HARDLINKS $COMPRESS $CUSTOM_ARGS --stats --progress --itemize-changes"
 
-COMMON_ARGS="--dry-run --archive $COMPRESS --stats --progress --itemize-changes "
+rsync $COMMON_ARGS --recursive --log-file=$LOG_FILE $EXCLUDE_ARG --delete . $BACKUP_TARGET
 
-rsync $COMMON_ARGS --recursive --log-file=$LOG_FILE $EXCLUDE_ARG --delete   .           $BACKUP_TARGET
-rsync $COMMON_ARGS                                                          $LOG_FILE   $BACKUP_TARGET
+# Sync logfile
+[[ ! -z "$DEBUG_ARGS" ]] && echo "SKIP: $LOG_FILE didn't sync due DEBUG_ARGS=$DEBUG_ARGS" || rsync $COMMON_ARGS $LOG_FILE $BACKUP_TARGET
 
 echo
 echo "Done! (press ENTER to exit)"


### PR DESCRIPTION
## v1.2.0

 * allow local backup by commenting `BACKUP_SERVER=`
 * auto suggest container name, introduce "storage" term
 * add --hard-links option
 * append container name by trailing slash "/"
 * skip sending backup.log for `--dry-run`
 * allow custom rsync args by `CUSTOM_ARGS=` or by passing shell arguments