### PR TITLE
v1.3.0 snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 win-share
+backup.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+## v1.3.0
+
+ * add `snapshot.sh` tool
+ * make backup with snapshot layout when snapshot.sh tool present in source directory
+ * invoke snapshot tool on storage after backup (locally or via ssh)
+ * fix `~/` expansion issue
+ * create target storage unless exist (mkdir -p, unless `--mkpath` become common in distros)
+
 ## v1.2.0
 
  * allow local backup by commenting BACKUP_SERVER=

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Single-file backup script which lives in the target directory alongside with dat
 
 Backup always simple as invoking `./backup.sh`
 
-NOTE: this is mirror-style backup, everything you have deleted in your working copy would be removed on a backup storage during sync (`rsync --delete` option). It's assumed your are using hard links snapshots on a backup storage if you'd like keep previous files versions.
+NOTE: this is **mirror-style backup**, everything you have deleted in your working copy would be removed on a backup storage during sync (`rsync --delete` option). It's assumed your are using hard links snapshots on a backup storage if you'd like keep previous files versions.
+
+Snapshot tool `snapshot.sh` would create new snapshot for you once backup finished. Just put `snapshot.sh` into directory alongside with `backup.sh`. Snapshots made in common rsync+hardlinks way. They aren't expand storage capacity, but you have to use filesystem with hardlinks support like `ext4`.
 
 ## Few concepts
 
@@ -28,9 +30,13 @@ By default **container** name is the current directory name, but you can overrid
 
 ## Prerequisites for Server and Client
 
-install rsync-3.1.2+
+Install rsync-3.1.2+, openssh, realpath, tee. Target storage filesystem with hard links support.
+
+All this pre-installed in common desktop Linux distros.
 
 ## Install rsync and ssh on Windows
+
+(tested on Windows 7)
 
  * Download from http://msys2.org/
  * Follow instructions for update packman
@@ -64,8 +70,8 @@ $ ssh-copy-id user@backup-server
 
 ## Setup backup config
 
- * Copy `backup-sample.sh` into target folder as `backup.sh`.
- * Open `backup.sh` and specify correct values for `BACKUP_SERVER` and `STORAGE`
+ * Copy `backup-sample.sh` into target directory, rename as you like. Let's assume it `backup.sh`.
+ * Open `backup.sh` and specify correct values for `BACKUP_SERVER` and `STORAGE`.
 
 Examples:
 
@@ -74,8 +80,12 @@ BACKUP_SERVER="user@backup-server"
 STORAGE="family_photos"
 ```
 
- * test in `--dry-run (-n)` mode
- * remove `--dry-run (-n)` option by commenting DEBUG= variable
+ * Invoke `backup.sh` in `--dry-run (-n)` mode. It's enabled by default by `DEBUG_ARGS=` param.
+ * Remove `--dry-run (-n)` option by commenting `DEBUG=` param.
+
+### Enable snapshots
+
+ * Copy `snapshot.sh` into target directory. That's it. You should keep name of the tool according `SNAPSHOT_TOOL=` param in your `backup.sh`. It's `snapshot.sh` by default.
 
 ### Windows launcher as .sh association
 

--- a/backup-sample.sh
+++ b/backup-sample.sh
@@ -2,7 +2,7 @@
 
 #
 # https://github.com/x2es/simple-rsync-backup
-# v1.2.0
+# v1.3.0
 # 
 
 # test your configuration and comment out DEBUG_ARGS after
@@ -17,7 +17,8 @@ STORAGE="backup/storage"
 # by default CONTAINER is the name of the current directory
 # CONTAINER="custom-name"
 
-LOG_FILE="./backup.log"
+LOG_FILENAME="backup.log"
+EXCLUDE_FILENAME="backup-ignore"
 
 # COMPRESS="--compress" # old compress
 COMPRESS="-zz" # works with rsync-3.1.2
@@ -33,29 +34,62 @@ COMPRESS="-zz" # works with rsync-3.1.2
 # --- CONFIG END --- #
 #                    #
 
-[[ -z "$CONTAINER" ]] && CONTAINER="$(basename $(pwd))"
-CONTAINER_PATH="$STORAGE/$CONTAINER"
+function die() {
+  echo "FATAL ERROR: ${@}"
+  exit 1
+}
+
+SNAPSHOT_WORK_COPY="recent"
+SNAPSHOT_TOOL="snapshot.sh"
 
 [[ ! -z "${@}" ]] && CUSTOM_ARGS="$CUSTOM_ARGS ${@}"
 
-[[ ! -z "$BACKUP_SERVER" ]]             && BACKUP_TARGET="$BACKUP_SERVER:"
-[[ "${CONTAINER_PATH:0:1}" != "/" ]]    && BACKUP_TARGET="${BACKUP_TARGET}~/"
-BACKUP_TARGET="${BACKUP_TARGET}${CONTAINER_PATH}/"
+EXEC_PATH="$(dirname $(realpath -s $0))"
+LOG_FILE="$EXEC_PATH/$LOG_FILENAME"
+EXCLUDE_LIST="$EXEC_PATH/$EXCLUDE_FILENAME"
+SNAPSHOT_TOOL_LOCAL_PATH="$EXEC_PATH/$SNAPSHOT_TOOL"
 
-EXCLUDE_LIST="./backup-ignore"
+[[ -z "$CONTAINER" ]] && CONTAINER="$(basename $EXEC_PATH)"
+CONTAINER_PATH="$STORAGE/$CONTAINER"
+
+# Treat non-absolute paths as home-based
+if [[ "${CONTAINER_PATH:0:1}" != "/" ]]; then
+  # due issue with expansion "~" for not yet existing paths
+  [[ ! -z "$BACKUP_SERVER" ]] && CONTAINER_PATH="~/$CONTAINER_PATH" || CONTAINER_PATH="$HOME/$CONTAINER_PATH"
+fi
+
+# Once snapshot tool exist use appropriate layout and invoke snapshot tool once backup finish
+if [[ -x "$SNAPSHOT_TOOL_LOCAL_PATH" ]]; then
+  IS_SNAPSHOT=1
+
+  # use snapshot directory layout
+  CONTAINER_PATH="$CONTAINER_PATH/$SNAPSHOT_WORK_COPY"
+
+  SNAPSHOT_CMD="$CONTAINER_PATH/$SNAPSHOT_TOOL"
+  # kind of `ssh user@server /path/to/container/snapshot.sh`
+  [[ ! -z "$BACKUP_SERVER" ]] && SNAPSHOT_CMD="ssh $BACKUP_SERVER $SNAPSHOT_CMD"
+fi
+
+[[ ! -z "$BACKUP_SERVER" ]] && BACKUP_TARGET="$BACKUP_SERVER:"
+BACKUP_TARGET="${BACKUP_TARGET}${CONTAINER_PATH}/"
+BACKUP_SOURCE="$EXEC_PATH/"
+
 EXCLUDE_ARG=""
 [[ -f $EXCLUDE_LIST ]] && EXCLUDE_ARG="--exclude-from=$EXCLUDE_LIST --delete-excluded"
 
 echo "Backup:"
 [[ ! -z "$DEBUG_ARGS" ]] && echo "  DEBUG: $DEBUG_ARGS"
 
-TARGET_NODE="$BACKUP_SERVER"
-[[ -z "$TARGET_NODE" ]] && TARGET_NODE="local"
+TARGET_NOTE="$BACKUP_SERVER"
+[[ -z "$TARGET_NOTE" ]] && TARGET_NOTE="local"
 
-echo "        dir: `pwd`"                
-echo "         to: $TARGET_NODE"
-echo "  container: $CONTAINER_PATH"
-[[ ! -z "$CUSTOM_ARGS" ]] && echo "custom args: $CUSTOM_ARGS"
+SNAPSHOT_NOTE=""
+[[ $IS_SNAPSHOT -eq 1 ]] && SNAPSHOT_NOTE="(snapshot layout)"
+
+echo "          dir: $BACKUP_SOURCE"                
+echo "           to: $TARGET_NOTE"
+echo "    container: $CONTAINER_PATH $SNAPSHOT_NOTE"
+[[ ! -z "$CUSTOM_ARGS" ]] && echo "  custom args: $CUSTOM_ARGS"
 
 if [[ "$EXCLUDE_ARG" != "" ]]; then
   echo
@@ -64,16 +98,35 @@ if [[ "$EXCLUDE_ARG" != "" ]]; then
   echo ">>>>>>>>>>>>>>>>>>"
 fi
 
+if [[ $IS_SNAPSHOT -eq 1 ]]; then
+  echo
+  echo "NOTE: snapshot layout applied due exising snapshot tool '$SNAPSHOT_TOOL_LOCAL_PATH'"
+fi
+
 echo
 echo "(press ENTER for continue / Ctrl+C for cancel)"
 read
 
 COMMON_ARGS="$DEBUG_ARGS --archive $HARDLINKS $COMPRESS $CUSTOM_ARGS --stats --progress --itemize-changes"
 
-rsync $COMMON_ARGS --recursive --log-file=$LOG_FILE $EXCLUDE_ARG --delete . $BACKUP_TARGET
+# DEPRECATED: since --mkpath added in rsync 3.2.3 (6 Aug 2020)
+MKDIR_P_CMD="mkdir -p $CONTAINER_PATH"
+[[ ! -z "$BACKUP_SERVER" ]] && MKDIR_P_CMD="ssh $BACKUP_SERVER $MKDIR_P_CMD"
+
+[[ -z "$DEBUG_ARGS" ]] && $MKDIR_P_CMD
+rsync $COMMON_ARGS --recursive --log-file=$LOG_FILE $EXCLUDE_ARG --delete $BACKUP_SOURCE $BACKUP_TARGET
+RSYNC_RESULT=$?
+[[ $RSYNC_RESULT -eq 0 ]] || die "rsync failed, see errors above"
+
 
 # Sync logfile
 [[ ! -z "$DEBUG_ARGS" ]] && echo "SKIP: $LOG_FILE didn't sync due DEBUG_ARGS=$DEBUG_ARGS" || rsync $COMMON_ARGS $LOG_FILE $BACKUP_TARGET
+
+# Invoke snapshot creation
+if [[ $IS_SNAPSHOT -eq 1 ]]; then
+  echo "Attempt to create snapshot invoking '$SNAPSHOT_CMD'" | tee -a $LOG_FILE
+  [[ ! -z "$DEBUG_ARGS" ]] && echo "SKIP: snapshot didn't invoke due DEBUG_ARGS=$DEBUG_ARGS" || $SNAPSHOT_CMD | tee -a $LOG_FILE
+fi
 
 echo
 echo "Done! (press ENTER to exit)"

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#
+# https://github.com/x2es/simple-rsync-backup
+# v1.3.0
+#
+
+WORK_COPY="recent"
+LOG_FILENAME="backup.log"
+
+TIMESTAMP_CMD="date +%Y%m%d-%H%M%S"
+
+function die() {
+  echo "FATAL ERROR: ${@}"
+  exit 1
+}
+
+EXEC_PATH="$(dirname $(realpath -s $0))"
+SNAPSHOTS_CONTAINER_PATH="$(dirname $EXEC_PATH)"
+TARGET_DIR="$(basename $EXEC_PATH)"
+
+[[ "$TARGET_DIR" == "$WORK_COPY" ]] || die "'$EXEC_PATH' is not valid snapshot work copy (expected '$EXEC_PATH/$WORK_COPY')"
+
+LOG_PATH="$EXEC_PATH/$LOG_FILENAME"
+TIMESTAMP="$(${TIMESTAMP_CMD})"
+
+WORK_COPY_PATH="$SNAPSHOTS_CONTAINER_PATH/$WORK_COPY"
+SNAPSHOT_PATH="$SNAPSHOTS_CONTAINER_PATH/$TIMESTAMP"
+
+echo "Creating snapshot $SNAPSHOT_PATH ..."         | tee -a $LOG_PATH
+cp -al $WORK_COPY_PATH $SNAPSHOT_PATH         2>&1  | tee -a $LOG_PATH
+echo "Done snapshot $SNAPSHOT_PATH"                 | tee -a $LOG_PATH
+


### PR DESCRIPTION
 * add `snapshot.sh` tool
 * make backup with snapshot layout when snapshot.sh tool present in source directory
 * invoke snapshot tool on storage after backup (locally or via ssh)
 * fix `~/` expansion issue
 * create target storage unless exist (mkdir -p, unless `--mkpath` become common in distros)